### PR TITLE
ToString() method implemented for architectural element classes

### DIFF
--- a/ArchitectureParser/Architecture/Components/ReusableComponent.cs
+++ b/ArchitectureParser/Architecture/Components/ReusableComponent.cs
@@ -13,5 +13,10 @@ namespace ArchitectureParser.Architecture.Components
         {
             InstanceName = instanceName;
         }
+
+        public override string ToString()
+        {
+            return string.Format("{0} ({1})", InstanceName, Name);
+        }
     }
 }

--- a/ArchitectureParser/Architecture/Connections/Connectable.cs
+++ b/ArchitectureParser/Architecture/Connections/Connectable.cs
@@ -31,5 +31,10 @@ namespace ArchitectureParser.Architecture.Connections
 
             return connection;
         }
+
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 }

--- a/ArchitectureParser/Architecture/Connections/Connection.cs
+++ b/ArchitectureParser/Architecture/Connections/Connection.cs
@@ -45,5 +45,10 @@ namespace ArchitectureParser.Architecture.Connections
             Destination      = destination;
             DestinationInput = destinationInput;
         }
+
+        public override string ToString()
+        {
+            return string.Format("{{{0}.{1}, {2}.{3}}}", Source.Name, SourceOutput, Destination.Name, DestinationInput);
+        }
     }
 }

--- a/ArchitectureParserTest/ReusableComponentTest.cs
+++ b/ArchitectureParserTest/ReusableComponentTest.cs
@@ -2,7 +2,6 @@
 using System;
 
 using ArchitectureParser.Architecture.Components;
-using ArchitectureParser.Architecture.Connections;
 
 namespace ArchitectureParserTest
 {


### PR DESCRIPTION
The `ToString()` method has been implemented for the following classes:
* `ReusableComponent`
* `Connection`
* `Connectable`

By overriding `ToString()` for the `Connectable` class, the method is overridden for the `Component` and `Composition` classes.