### PR TITLE
ReusableComponent Separated from Component

### DIFF
--- a/ArchitectureParser/Architecture/Components/Component.cs
+++ b/ArchitectureParser/Architecture/Components/Component.cs
@@ -30,5 +30,10 @@ namespace ArchitectureParser.Architecture.Components
 
             return connection;
         }
+
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 }

--- a/ArchitectureParser/Architecture/Components/NullComponent.cs
+++ b/ArchitectureParser/Architecture/Components/NullComponent.cs
@@ -31,5 +31,10 @@ namespace ArchitectureParser.Architecture.Components
         {
             return NullConnection.Instance;
         }
+
+        public override string ToString()
+        {
+            return "Null Component";
+        }
     }
 }

--- a/ArchitectureParser/Architecture/Components/NullComponent.cs
+++ b/ArchitectureParser/Architecture/Components/NullComponent.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 
-using ArchitectureParser.Architecture.Components;
 using ArchitectureParser.Architecture.Connections;
+using ArchitectureParser.Architecture.NullObjects;
 
-namespace ArchitectureParser.Architecture.NullObjects
+namespace ArchitectureParser.Architecture.Components
 {
     public sealed class NullComponent : IComponent
     {

--- a/ArchitectureParser/Architecture/Compositions/Composition.cs
+++ b/ArchitectureParser/Architecture/Compositions/Composition.cs
@@ -5,7 +5,7 @@ using ArchitectureParser.Architecture.Connections;
 using ArchitectureParser.Architecture.Exceptions;
 using ArchitectureParser.Architecture.Factories;
 
-namespace ArchitectureParser.Architecture.Components
+namespace ArchitectureParser.Architecture.Compositions
 {
     public class Composition : IComposition
     {

--- a/ArchitectureParser/Architecture/Compositions/Composition.cs
+++ b/ArchitectureParser/Architecture/Compositions/Composition.cs
@@ -140,5 +140,10 @@ namespace ArchitectureParser.Architecture.Compositions
             Connections.Clear();
             Contents.Clear();
         }
+
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 }

--- a/ArchitectureParser/Architecture/Compositions/IComposition.cs
+++ b/ArchitectureParser/Architecture/Compositions/IComposition.cs
@@ -2,7 +2,7 @@
 
 using ArchitectureParser.Architecture.Connections;
 
-namespace ArchitectureParser.Architecture.Components
+namespace ArchitectureParser.Architecture.Compositions
 {
     public interface IComposition : IConnectable
     {

--- a/ArchitectureParser/Architecture/Compositions/NullComposition.cs
+++ b/ArchitectureParser/Architecture/Compositions/NullComposition.cs
@@ -43,5 +43,10 @@ namespace ArchitectureParser.Architecture.Compositions
         {
             return;
         }
+
+        public override string ToString()
+        {
+            return "Null Composition";
+        }
     }
 }

--- a/ArchitectureParser/Architecture/Compositions/NullComposition.cs
+++ b/ArchitectureParser/Architecture/Compositions/NullComposition.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 
-using ArchitectureParser.Architecture.Components;
 using ArchitectureParser.Architecture.Connections;
+using ArchitectureParser.Architecture.NullObjects;
 
-namespace ArchitectureParser.Architecture.NullObjects
+namespace ArchitectureParser.Architecture.Compositions
 {
     public sealed class NullComposition : IComposition
     {

--- a/ArchitectureParser/Architecture/Connections/NullConnection.cs
+++ b/ArchitectureParser/Architecture/Connections/NullConnection.cs
@@ -38,5 +38,10 @@ namespace ArchitectureParser.Architecture.Connections
         {
             return;
         }
+
+        public override string ToString()
+        {
+            return "Null Connection";
+        }
     }
 }

--- a/ArchitectureParser/Architecture/Connections/NullConnection.cs
+++ b/ArchitectureParser/Architecture/Connections/NullConnection.cs
@@ -1,6 +1,6 @@
-﻿using ArchitectureParser.Architecture.Connections;
+﻿using ArchitectureParser.Architecture.Components;
 
-namespace ArchitectureParser.Architecture.NullObjects
+namespace ArchitectureParser.Architecture.Connections
 {
     public sealed class NullConnection : IConnection
     {

--- a/ArchitectureParser/Architecture/Exceptions/NoProvidingSourceException.cs
+++ b/ArchitectureParser/Architecture/Exceptions/NoProvidingSourceException.cs
@@ -18,5 +18,10 @@ namespace ArchitectureParser.Architecture.Exceptions
         {
 
         }
+
+        public override string ToString()
+        {
+            return Message;
+        }
     }
 }

--- a/ArchitectureParser/Architecture/Factories/ComponentFactory.cs
+++ b/ArchitectureParser/Architecture/Factories/ComponentFactory.cs
@@ -1,5 +1,4 @@
 ﻿using ArchitectureParser.Architecture.Components;
-using ArchitectureParser.Architecture.ReusableComponents;
 
 namespace ArchitectureParser.Architecture.Factories
 {
@@ -12,15 +11,6 @@ namespace ArchitectureParser.Architecture.Factories
             if (string.IsNullOrWhiteSpace(name))
             {
                 component = NullComponent.Instance;
-            }
-
-            else if (name.Replace("<br>", " ").Replace("\r", "").Replace("\n", " ").Contains(" "))
-            {
-                var nameParts = name.Replace("<br>", " ").Replace("\r", "").Replace("\n", " ").Split();
-                var instanceName = nameParts[0];
-                var componentName = nameParts[1];
-
-                component = new ReusableComponent(instanceName, componentName);
             }
 
             else

--- a/ArchitectureParser/Architecture/Factories/ComponentFactory.cs
+++ b/ArchitectureParser/Architecture/Factories/ComponentFactory.cs
@@ -1,5 +1,5 @@
 ﻿using ArchitectureParser.Architecture.Components;
-using ArchitectureParser.Architecture.NullObjects;
+using ArchitectureParser.Architecture.ReusableComponents;
 
 namespace ArchitectureParser.Architecture.Factories
 {

--- a/ArchitectureParser/Architecture/Factories/CompositionFactory.cs
+++ b/ArchitectureParser/Architecture/Factories/CompositionFactory.cs
@@ -1,5 +1,4 @@
-﻿using ArchitectureParser.Architecture.Components;
-using ArchitectureParser.Architecture.NullObjects;
+﻿using ArchitectureParser.Architecture.Compositions;
 
 namespace ArchitectureParser.Architecture.Factories
 {

--- a/ArchitectureParser/Architecture/Factories/ConnectionFactory.cs
+++ b/ArchitectureParser/Architecture/Factories/ConnectionFactory.cs
@@ -1,5 +1,4 @@
 ﻿using ArchitectureParser.Architecture.Connections;
-using ArchitectureParser.Architecture.NullObjects;
 
 namespace ArchitectureParser.Architecture.Factories
 {

--- a/ArchitectureParser/Architecture/Factories/ReusableComponentFactory.cs
+++ b/ArchitectureParser/Architecture/Factories/ReusableComponentFactory.cs
@@ -1,0 +1,24 @@
+﻿using ArchitectureParser.Architecture.ReusableComponents;
+
+namespace ArchitectureParser.Architecture.Factories
+{
+    public static class ReusableComponentFactory
+    {
+        public static IReusableComponent Create(string instanceName, string baseName)
+        {
+            IReusableComponent reusableComponent;
+
+            if (string.IsNullOrWhiteSpace(instanceName) || string.IsNullOrWhiteSpace(baseName))
+            {
+                reusableComponent = NullReusableComponent.Instance;
+            }
+
+            else
+            {
+                reusableComponent = new ReusableComponent(instanceName, baseName);
+            }
+
+            return reusableComponent;
+        }
+    }
+}

--- a/ArchitectureParser/Architecture/ReusableComponents/IReusableComponent.cs
+++ b/ArchitectureParser/Architecture/ReusableComponents/IReusableComponent.cs
@@ -1,0 +1,10 @@
+﻿using ArchitectureParser.Architecture.Connections;
+
+namespace ArchitectureParser.Architecture.ReusableComponents
+{
+    public interface IReusableComponent : IConnectable
+    {
+        string InstanceName      { get; }
+        string BaseComponentName { get; }
+    }
+}

--- a/ArchitectureParser/Architecture/ReusableComponents/NullReusableComponent.cs
+++ b/ArchitectureParser/Architecture/ReusableComponents/NullReusableComponent.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+
+using ArchitectureParser.Architecture.Connections;
+using ArchitectureParser.Architecture.NullObjects;
+
+
+namespace ArchitectureParser.Architecture.ReusableComponents
+{
+    public sealed class NullReusableComponent : IReusableComponent
+    {
+        private static NullReusableComponent m_instance;
+        public  static NullReusableComponent Instance { get { return m_instance ?? (m_instance = new NullReusableComponent()); } }
+
+        private NullSet<IConnection> m_connections;
+
+        public string BaseComponentName
+        {
+            get { return string.Empty; }
+        }
+
+        public string InstanceName
+        {
+            get { return string.Empty; }
+        }
+
+        public ISet<IConnection> Connections
+        {
+            get { return m_connections; }
+        }
+
+        private NullReusableComponent()
+        {
+            m_connections = new NullSet<IConnection>();
+        }
+
+        public IConnection Connect(IConnectable destination, string outputName, string inputName)
+        {
+            return NullConnection.Instance;
+        }
+
+        public override string ToString()
+        {
+            return "Null Reusable Component";
+        }
+    }
+}

--- a/ArchitectureParser/Architecture/ReusableComponents/ReusableComponent.cs
+++ b/ArchitectureParser/Architecture/ReusableComponents/ReusableComponent.cs
@@ -1,16 +1,15 @@
 ﻿using System.Collections.Generic;
 
-using ArchitectureParser.Architecture.Components;
 using ArchitectureParser.Architecture.Connections;
 using ArchitectureParser.Architecture.Factories;
 
 namespace ArchitectureParser.Architecture.ReusableComponents
 {
-    public class ReusableComponent : IComponent
+    public class ReusableComponent : IReusableComponent
     {
         private HashSet<IConnection> m_connections;
 
-        public string Name
+        public string BaseComponentName
         {
             get;
         }
@@ -27,9 +26,9 @@ namespace ArchitectureParser.Architecture.ReusableComponents
         
         public ReusableComponent(string instanceName, string baseComponentName)
         {
-            InstanceName  = instanceName;
-            Name          = baseComponentName;
-            m_connections = new HashSet<IConnection>();
+            InstanceName      = instanceName;
+            BaseComponentName = baseComponentName;
+            m_connections     = new HashSet<IConnection>();
         }
 
         public IConnection Connect(IConnectable destination, string outputName, string inputName)
@@ -43,7 +42,7 @@ namespace ArchitectureParser.Architecture.ReusableComponents
 
         public override string ToString()
         {
-            return string.Format("{0} ({1})", InstanceName, Name);
+            return string.Format("{0} ({1})", InstanceName, BaseComponentName);
         }
     }
 }

--- a/ArchitectureParser/Architecture/ReusableComponents/ReusableComponent.cs
+++ b/ArchitectureParser/Architecture/ReusableComponents/ReusableComponent.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
 
+using ArchitectureParser.Architecture.Components;
 using ArchitectureParser.Architecture.Connections;
 using ArchitectureParser.Architecture.Factories;
 
-namespace ArchitectureParser.Architecture.Components
+namespace ArchitectureParser.Architecture.ReusableComponents
 {
     public class ReusableComponent : IComponent
     {

--- a/ArchitectureParser/ArchitectureParser.csproj
+++ b/ArchitectureParser/ArchitectureParser.csproj
@@ -45,10 +45,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Architecture\Components\Component.cs" />
-    <Compile Include="Architecture\Components\Composition.cs" />
+    <Compile Include="Architecture\Compositions\Composition.cs" />
     <Compile Include="Architecture\Components\IComponent.cs" />
-    <Compile Include="Architecture\Components\IComposition.cs" />
-    <Compile Include="Architecture\Components\ReusableComponent.cs" />
+    <Compile Include="Architecture\Compositions\IComposition.cs" />
+    <Compile Include="Architecture\ReusableComponents\ReusableComponent.cs" />
     <Compile Include="Architecture\Connections\Connection.cs" />
     <Compile Include="Architecture\Connections\IConnectable.cs" />
     <Compile Include="Architecture\Connections\IConnection.cs" />
@@ -56,9 +56,9 @@
     <Compile Include="Architecture\Factories\ComponentFactory.cs" />
     <Compile Include="Architecture\Factories\CompositionFactory.cs" />
     <Compile Include="Architecture\Factories\ConnectionFactory.cs" />
-    <Compile Include="Architecture\NullObjects\NullComponent.cs" />
-    <Compile Include="Architecture\NullObjects\NullComposition.cs" />
-    <Compile Include="Architecture\NullObjects\NullConnection.cs" />
+    <Compile Include="Architecture\Components\NullComponent.cs" />
+    <Compile Include="Architecture\Compositions\NullComposition.cs" />
+    <Compile Include="Architecture\Connections\NullConnection.cs" />
     <Compile Include="Architecture\NullObjects\NullSet.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>

--- a/ArchitectureParser/ArchitectureParser.csproj
+++ b/ArchitectureParser/ArchitectureParser.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Architecture\Compositions\Composition.cs" />
     <Compile Include="Architecture\Components\IComponent.cs" />
     <Compile Include="Architecture\Compositions\IComposition.cs" />
+    <Compile Include="Architecture\ReusableComponents\IReusableComponent.cs" />
     <Compile Include="Architecture\ReusableComponents\ReusableComponent.cs" />
     <Compile Include="Architecture\Connections\Connection.cs" />
     <Compile Include="Architecture\Connections\IConnectable.cs" />

--- a/ArchitectureParser/ArchitectureParser.csproj
+++ b/ArchitectureParser/ArchitectureParser.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Architecture\Components\IComponent.cs" />
     <Compile Include="Architecture\Compositions\IComposition.cs" />
     <Compile Include="Architecture\ReusableComponents\IReusableComponent.cs" />
+    <Compile Include="Architecture\ReusableComponents\NullReusableComponent.cs" />
     <Compile Include="Architecture\ReusableComponents\ReusableComponent.cs" />
     <Compile Include="Architecture\Connections\Connection.cs" />
     <Compile Include="Architecture\Connections\IConnectable.cs" />

--- a/ArchitectureParser/ArchitectureParser.csproj
+++ b/ArchitectureParser/ArchitectureParser.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Architecture\Compositions\Composition.cs" />
     <Compile Include="Architecture\Components\IComponent.cs" />
     <Compile Include="Architecture\Compositions\IComposition.cs" />
+    <Compile Include="Architecture\Factories\ReusableComponentFactory.cs" />
     <Compile Include="Architecture\ReusableComponents\IReusableComponent.cs" />
     <Compile Include="Architecture\ReusableComponents\NullReusableComponent.cs" />
     <Compile Include="Architecture\ReusableComponents\ReusableComponent.cs" />

--- a/ArchitectureParserTest/ComponentTest.cs
+++ b/ArchitectureParserTest/ComponentTest.cs
@@ -2,7 +2,7 @@
 
 using ArchitectureParser.Architecture.Components;
 using ArchitectureParser.Architecture.Factories;
-using ArchitectureParser.Architecture.NullObjects;
+using ArchitectureParser.Architecture.Connections;
 
 namespace ArchitectureParserTest
 {

--- a/ArchitectureParserTest/CompositionTest.cs
+++ b/ArchitectureParserTest/CompositionTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using ArchitectureParser.Architecture.Components;
 using ArchitectureParser.Architecture.Factories;
 using ArchitectureParser.Architecture.Exceptions;
+using ArchitectureParser.Architecture.Compositions;
 
 namespace ArchitectureParserTest
 {

--- a/ArchitectureParserTest/ConnectionTest.cs
+++ b/ArchitectureParserTest/ConnectionTest.cs
@@ -2,7 +2,7 @@
 
 using ArchitectureParser.Architecture.Components;
 using ArchitectureParser.Architecture.Factories;
-using ArchitectureParser.Architecture.NullObjects;
+using ArchitectureParser.Architecture.Connections;
 
 namespace ArchitectureParserTest
 {

--- a/ArchitectureParserTest/ReusableComponentTest.cs
+++ b/ArchitectureParserTest/ReusableComponentTest.cs
@@ -18,35 +18,34 @@ namespace ArchitectureParserTest
         private static string InputName  = @"Input";
         private static string OutputName = @"Output";
 
-        private static IComponent ComponentBreak()   => ComponentFactory.Create(string.Format("{0}<br>{1}", InstanceName, BaseName));
-        private static IComponent ComponentNewline() => ComponentFactory.Create(string.Format("{0}\n{1}", InstanceName, BaseName));
+        private static IReusableComponent ReusableComponent() => ReusableComponentFactory.Create(InstanceName, BaseName);
 
         private static IComponent Component() => ComponentFactory.Create(ComponentName);
 
         [TestMethod]
         public void ReusableComponentConstructor()
         {
-            var reusableComponent = ComponentBreak() as ReusableComponent;
+            var reusableComponent = ReusableComponent();
 
             Assert.AreEqual(InstanceName, reusableComponent.InstanceName);
-            Assert.AreEqual(BaseName,     reusableComponent.Name);
+            Assert.AreEqual(BaseName,     reusableComponent.BaseComponentName);
             Assert.AreEqual(0,            reusableComponent.Connections.Count);
         }
 
         [TestMethod]
         public void ReusableComponentConstructor2()
         {
-            var reusableComponent = ComponentNewline() as ReusableComponent;
+            var reusableComponent = ReusableComponent();
 
             Assert.AreEqual(InstanceName, reusableComponent.InstanceName);
-            Assert.AreEqual(BaseName, reusableComponent.Name);
+            Assert.AreEqual(BaseName, reusableComponent.BaseComponentName);
             Assert.AreEqual(0, reusableComponent.Connections.Count);
         }
 
         [TestMethod]
         public void ReusableComponentConnect()
         {
-            var reusableComponent = ComponentBreak() as ReusableComponent;
+            var reusableComponent = ReusableComponent();
             var component         = Component();
             var connection        = reusableComponent.Connect(component, OutputName, InputName);
 
@@ -61,7 +60,7 @@ namespace ArchitectureParserTest
         [TestMethod]
         public void ReusableComponentConnectToNullDestination()
         {
-            var reusableComponent = ComponentBreak() as ReusableComponent;
+            var reusableComponent = ReusableComponent();
             var connection = reusableComponent.Connect(null, OutputName, null);
 
             Assert.IsTrue(connection is NullConnection);

--- a/ArchitectureParserTest/ReusableComponentTest.cs
+++ b/ArchitectureParserTest/ReusableComponentTest.cs
@@ -2,7 +2,8 @@
 
 using ArchitectureParser.Architecture.Components;
 using ArchitectureParser.Architecture.Factories;
-using ArchitectureParser.Architecture.NullObjects;
+using ArchitectureParser.Architecture.ReusableComponents;
+using ArchitectureParser.Architecture.Connections;
 
 namespace ArchitectureParserTest
 {


### PR DESCRIPTION
`ReusableComponent` is now it's own entity backed by a null object and a factory.

Closes #14 